### PR TITLE
Disable authorizer after command (fixes #6)

### DIFF
--- a/src/gmodule/stats/stats-command.c
+++ b/src/gmodule/stats/stats-command.c
@@ -1600,6 +1600,14 @@ command_process(struct client *client, char *line)
 	if (cmd)
 		ret = cmd->handler(client, argc, argv);
 
+	/* Disable the authorizer again */
+	if (!db_set_authorizer(NULL, NULL, &error)) {
+		command_error(client, error->code, "%s", error->message);
+		current_command = NULL;
+		g_error_free(error);
+		return COMMAND_RETURN_ERROR;
+	}
+
 	current_command = NULL;
 	return ret;
 }


### PR DESCRIPTION
After processing a command on the server the authorizer has to be disabled again by setting it to NULL. Otherwise other database operations like saving song statistics might be denied.

This should fix issue #6.
